### PR TITLE
feat: starting support of no-std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,10 +8,15 @@ repository = "https://github.com/dariusc93/pollable-map"
 authors = ["Darius Clark"]
 exclude = [".gitignore"]
 
+[features]
+default = ["std", "alloc"]
+std = ["futures/std", "futures-timeout"]
+alloc = ["futures/alloc"]
+
 
 [dependencies]
-futures = { version = "0.3.31", default-features = false, features = ["std", "alloc", "async-await"] }
-futures-timeout = "0.1.3"
+futures = { version = "0.3.31", default-features = false, features = ["async-await"] }
+futures-timeout = { version = "0.1.3", optional = true }
 
 [dev-dependencies]
 futures = { version = "0.3.31", default-features = false, features = ["std", "alloc", "async-await", "thread-pool", "executor"] }

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,10 +1,10 @@
-use futures::{FutureExt, Stream, StreamExt};
+use core::future::Future;
+use core::pin::Pin;
+use core::task::{Context, Poll};
+use futures::Stream;
+
+#[cfg(feature = "std")]
 use futures_timeout::{Timeout, TimeoutExt};
-use std::future::Future;
-use std::ops::{Deref, DerefMut};
-use std::pin::Pin;
-use std::task::{Context, Poll};
-use std::time::Duration;
 
 pub struct InnerMap<K, S> {
     key: K,
@@ -125,49 +125,56 @@ where
     }
 }
 
+#[cfg(feature = "std")]
 pub struct Timed<F>(Timeout<F>);
 
+#[cfg(feature = "std")]
 impl<F> Timed<F> {
     pub(crate) fn into_inner(self) -> F {
         self.0.into_inner()
     }
 }
 
-impl<F> Deref for Timed<F> {
+#[cfg(feature = "std")]
+impl<F> core::ops::Deref for Timed<F> {
     type Target = F;
     fn deref(&self) -> &Self::Target {
         self.0.deref()
     }
 }
 
-impl<F> DerefMut for Timed<F> {
+#[cfg(feature = "std")]
+impl<F> core::ops::DerefMut for Timed<F> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.0.deref_mut()
     }
 }
 
+#[cfg(feature = "std")]
 impl<F> Timed<F> {
-    pub(crate) fn new(item: F, timeout: Duration) -> Self {
+    pub(crate) fn new(item: F, timeout: core::time::Duration) -> Self {
         Self(item.timeout(timeout))
     }
 }
 
+#[cfg(feature = "std")]
 impl<F> Future for Timed<F>
 where
     F: Future + Unpin,
 {
     type Output = std::io::Result<F::Output>;
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        self.0.poll_unpin(cx)
+        Pin::new(&mut self.0).poll(cx)
     }
 }
 
+#[cfg(feature = "std")]
 impl<F> Stream for Timed<F>
 where
     F: Stream + Unpin,
 {
     type Item = std::io::Result<F::Item>;
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        self.0.poll_next_unpin(cx)
+        Pin::new(&mut self.0).poll_next(cx)
     }
 }

--- a/src/futures.rs
+++ b/src/futures.rs
@@ -36,8 +36,8 @@ impl<K, T> FutureMap<K, T> {
 
 impl<K, T> FutureMap<K, T>
 where
-    K: Clone + PartialEq + Send + Unpin + 'static,
-    T: Future + Send + Unpin + 'static,
+    K: Clone + PartialEq + Unpin,
+    T: Future + Unpin,
 {
     /// Insert a future into the map with a unique key.
     /// The function will return true if the map does not have the key present,
@@ -162,8 +162,8 @@ where
 
 impl<K, T> FromIterator<(K, T)> for FutureMap<K, T>
 where
-    K: Clone + PartialEq + Send + Unpin + 'static,
-    T: Future + Send + Unpin + 'static,
+    K: Clone + PartialEq + Unpin,
+    T: Future + Unpin,
 {
     fn from_iter<I: IntoIterator<Item = (K, T)>>(iter: I) -> Self {
         let mut maps = Self::new();
@@ -176,8 +176,8 @@ where
 
 impl<K, T> Stream for FutureMap<K, T>
 where
-    K: Clone + PartialEq + Send + Unpin + 'static,
-    T: Future + Unpin + Send + 'static,
+    K: Clone + PartialEq + Unpin,
+    T: Future + Unpin,
 {
     type Item = (K, T::Output);
 
@@ -220,8 +220,8 @@ where
 
 impl<K, T> FusedStream for FutureMap<K, T>
 where
-    K: Clone + PartialEq + Send + Unpin + 'static,
-    T: Future + Unpin + Send + 'static,
+    K: Clone + PartialEq + Unpin,
+    T: Future + Unpin,
 {
     fn is_terminated(&self) -> bool {
         self.list.is_terminated()

--- a/src/futures.rs
+++ b/src/futures.rs
@@ -1,7 +1,9 @@
 pub mod optional;
 pub mod ordered;
 pub mod set;
+#[cfg(feature = "std")]
 pub mod timeout_map;
+#[cfg(feature = "std")]
 pub mod timeout_set;
 
 use crate::common::InnerMap;

--- a/src/futures.rs
+++ b/src/futures.rs
@@ -5,11 +5,11 @@ pub mod timeout_map;
 pub mod timeout_set;
 
 use crate::common::InnerMap;
+use core::future::Future;
+use core::pin::Pin;
+use core::task::{Context, Poll, Waker};
 use futures::stream::{FusedStream, FuturesUnordered};
 use futures::{Stream, StreamExt};
-use std::future::Future;
-use std::pin::Pin;
-use std::task::{Context, Poll, Waker};
 
 pub struct FutureMap<K, S> {
     list: FuturesUnordered<InnerMap<K, S>>,

--- a/src/futures/optional.rs
+++ b/src/futures/optional.rs
@@ -2,7 +2,7 @@ use crate::optional::Optional;
 
 /// A reusable future that is the equivalent to an `Option`.
 ///
-/// By default, this future will be empty, which would return  [`Poll::Pending`] when polled,
+/// By default, this future will be empty, which would return [`Poll::Pending`] when polled,
 /// but if a [`Future`] is supplied either upon construction via [`OptionalFuture::new`] or
 /// is set via [`OptionalFuture::replace`], the future would then be polled once [`OptionalFuture`]
 /// is polled. Once the future is polled to completion, the results will be returned, with

--- a/src/futures/ordered.rs
+++ b/src/futures/ordered.rs
@@ -1,8 +1,8 @@
+use alloc::collections::VecDeque;
+use core::future::Future;
+use core::pin::Pin;
+use core::task::{Context, Poll, Waker};
 use futures::Stream;
-use std::collections::VecDeque;
-use std::future::Future;
-use std::pin::Pin;
-use std::task::{Context, Poll, Waker};
 
 /// An unbounded queue of futures imposed a FIFO order while polling one future at a time
 /// and returning the output to stream before popping the next future in queue to be polled.

--- a/src/futures/ordered.rs
+++ b/src/futures/ordered.rs
@@ -57,7 +57,7 @@ impl<F> OrderedFutureSet<F> {
 
 impl<F> FromIterator<F> for OrderedFutureSet<F>
 where
-    F: Future + Send + Unpin + 'static,
+    F: Future + Unpin,
 {
     fn from_iter<T: IntoIterator<Item = F>>(iter: T) -> Self {
         let mut ordered = Self::new();
@@ -70,7 +70,7 @@ where
 
 impl<F> Stream for OrderedFutureSet<F>
 where
-    F: Future + Send + Unpin + 'static,
+    F: Future + Unpin,
 {
     type Item = F::Output;
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
@@ -109,6 +109,8 @@ where
 #[cfg(test)]
 mod tests {
     use crate::futures::ordered::OrderedFutureSet;
+    use alloc::vec;
+    use alloc::vec::Vec;
     use futures::StreamExt;
 
     #[test]

--- a/src/futures/set.rs
+++ b/src/futures/set.rs
@@ -13,7 +13,7 @@ pub struct FutureSet<S> {
 
 impl<S> Default for FutureSet<S>
 where
-    S: Future + Send + Unpin + 'static,
+    S: Future + Unpin,
 {
     fn default() -> Self {
         Self::new()
@@ -22,7 +22,7 @@ where
 
 impl<S> FutureSet<S>
 where
-    S: Future + Send + Unpin + 'static,
+    S: Future + Unpin,
 {
     /// Creates an empty ['FutureSet`]
     pub fn new() -> Self {
@@ -71,7 +71,7 @@ where
 
 impl<S> FromIterator<S> for FutureSet<S>
 where
-    S: Future + Send + Unpin + 'static,
+    S: Future + Unpin,
 {
     fn from_iter<I: IntoIterator<Item = S>>(iter: I) -> Self {
         let mut maps = Self::new();
@@ -84,7 +84,7 @@ where
 
 impl<S> Stream for FutureSet<S>
 where
-    S: Future + Send + Unpin + 'static,
+    S: Future + Unpin,
 {
     type Item = S::Output;
 
@@ -101,7 +101,7 @@ where
 
 impl<S> FusedStream for FutureSet<S>
 where
-    S: Future + Send + Unpin + 'static,
+    S: Future + Unpin,
 {
     fn is_terminated(&self) -> bool {
         self.map.is_terminated()

--- a/src/futures/set.rs
+++ b/src/futures/set.rs
@@ -1,10 +1,10 @@
-use std::future::Future;
-use std::pin::Pin;
+use core::future::Future;
+use core::pin::Pin;
 
 use super::FutureMap;
+use core::task::{Context, Poll};
 use futures::stream::FusedStream;
 use futures::{Stream, StreamExt};
-use std::task::{Context, Poll};
 
 pub struct FutureSet<S> {
     id: i64,

--- a/src/futures/timeout_map.rs
+++ b/src/futures/timeout_map.rs
@@ -1,12 +1,12 @@
 use crate::common::Timed;
 use crate::futures::FutureMap;
+use core::future::Future;
+use core::ops::{Deref, DerefMut};
+use core::pin::Pin;
+use core::task::{Context, Poll};
+use core::time::Duration;
 use futures::stream::FusedStream;
 use futures::{Stream, StreamExt};
-use std::future::Future;
-use std::ops::{Deref, DerefMut};
-use std::pin::Pin;
-use std::task::{Context, Poll};
-use std::time::Duration;
 
 pub struct TimeoutFutureMap<K, F> {
     duration: Duration,

--- a/src/futures/timeout_map.rs
+++ b/src/futures/timeout_map.rs
@@ -28,8 +28,8 @@ impl<K, F> DerefMut for TimeoutFutureMap<K, F> {
 
 impl<K, F> TimeoutFutureMap<K, F>
 where
-    K: Clone + PartialEq + Send + Unpin + 'static,
-    F: Future + Send + Unpin + 'static,
+    K: Clone + PartialEq + Unpin,
+    F: Future + Unpin,
 {
     /// Create an empty [`TimeoutFutureMap`]
     pub fn new(duration: Duration) -> Self {
@@ -49,8 +49,8 @@ where
 
 impl<K, F> Stream for TimeoutFutureMap<K, F>
 where
-    K: Clone + PartialEq + Send + Unpin + 'static,
-    F: Future + Send + Unpin + 'static,
+    K: Clone + PartialEq + Unpin,
+    F: Future + Unpin,
 {
     type Item = (K, std::io::Result<F::Output>);
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
@@ -64,8 +64,8 @@ where
 
 impl<K, F> FusedStream for TimeoutFutureMap<K, F>
 where
-    K: Clone + PartialEq + Send + Unpin + 'static,
-    F: Future + Send + Unpin + 'static,
+    K: Clone + PartialEq + Unpin,
+    F: Future + Unpin,
 {
     fn is_terminated(&self) -> bool {
         self.map.is_terminated()

--- a/src/futures/timeout_set.rs
+++ b/src/futures/timeout_set.rs
@@ -1,12 +1,12 @@
 use crate::common::Timed;
 use crate::futures::set::FutureSet;
+use core::future::Future;
+use core::ops::{Deref, DerefMut};
+use core::pin::Pin;
+use core::task::{Context, Poll};
+use core::time::Duration;
 use futures::stream::FusedStream;
 use futures::{Stream, StreamExt};
-use std::future::Future;
-use std::ops::{Deref, DerefMut};
-use std::pin::Pin;
-use std::task::{Context, Poll};
-use std::time::Duration;
 
 pub struct TimeoutFutureSet<S> {
     duration: Duration,

--- a/src/futures/timeout_set.rs
+++ b/src/futures/timeout_set.rs
@@ -28,7 +28,7 @@ impl<S> DerefMut for TimeoutFutureSet<S> {
 
 impl<F> TimeoutFutureSet<F>
 where
-    F: Future + Send + Unpin + 'static,
+    F: Future + Unpin,
 {
     /// Create an empty [`TimeoutFutureSet`]
     pub fn new(duration: Duration) -> Self {
@@ -46,7 +46,7 @@ where
 
 impl<F> Stream for TimeoutFutureSet<F>
 where
-    F: Future + Send + Unpin + 'static,
+    F: Future + Unpin,
 {
     type Item = std::io::Result<F::Output>;
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
@@ -60,7 +60,7 @@ where
 
 impl<F> FusedStream for TimeoutFutureSet<F>
 where
-    F: Future + Send + Unpin + 'static,
+    F: Future + Unpin,
 {
     fn is_terminated(&self) -> bool {
         self.set.is_terminated()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,14 @@
+#![no_main]
+
+#[cfg(feature = "alloc")]
+extern crate alloc;
+#[cfg(feature = "std")]
+extern crate std;
+
+#[cfg(feature = "alloc")]
 pub mod futures;
+
+#[cfg(feature = "alloc")]
 pub mod stream;
 
 pub(crate) mod common;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![no_main]
+#![no_std]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/src/optional.rs
+++ b/src/optional.rs
@@ -1,11 +1,12 @@
+#[cfg(feature = "std")]
 pub mod timeout;
 
+use core::future::Future;
+use core::pin::Pin;
+use core::task::{Context, Poll, Waker};
 use futures::future::FusedFuture;
 use futures::stream::FusedStream;
 use futures::Stream;
-use std::future::Future;
-use std::pin::Pin;
-use std::task::{Context, Poll, Waker};
 
 /// A reusable future or stream based on `Option`.
 ///

--- a/src/optional/timeout.rs
+++ b/src/optional/timeout.rs
@@ -1,11 +1,11 @@
 use crate::common::Timed;
 use crate::optional::Optional;
+use core::future::Future;
+use core::ops::{Deref, DerefMut};
+use core::pin::Pin;
+use core::task::{Context, Poll};
+use core::time::Duration;
 use futures::Stream;
-use std::future::Future;
-use std::ops::{Deref, DerefMut};
-use std::pin::Pin;
-use std::task::{Context, Poll};
-use std::time::Duration;
 
 /// A reusable future or stream based on `Option` that will time out after a specific duration as elapse.
 pub struct TimeoutOptional<T> {

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -19,7 +19,7 @@ pub struct StreamMap<K, S> {
 impl<K, T> Default for StreamMap<K, T>
 where
     K: Clone + Unpin,
-    T: Stream + Send + Unpin + 'static,
+    T: Stream + Unpin,
 {
     fn default() -> Self {
         Self::new()
@@ -29,7 +29,7 @@ where
 impl<K, T> StreamMap<K, T>
 where
     K: Clone + Unpin,
-    T: Stream + Send + Unpin + 'static,
+    T: Stream + Unpin,
 {
     /// Creates an empty [`StreamMap`]
     pub fn new() -> Self {
@@ -43,8 +43,8 @@ where
 
 impl<K, T> StreamMap<K, T>
 where
-    K: Clone + PartialEq + Send + Unpin + 'static,
-    T: Stream + Send + Unpin + 'static,
+    K: Clone + PartialEq + Unpin,
+    T: Stream + Unpin,
 {
     /// Insert a stream into the map with a unique key.
     /// The function will return true if the map does not have the key present,
@@ -169,8 +169,8 @@ where
 
 impl<K, T> FromIterator<(K, T)> for StreamMap<K, T>
 where
-    K: Clone + PartialEq + Send + Unpin + 'static,
-    T: Stream + Send + Unpin + 'static,
+    K: Clone + PartialEq + Unpin,
+    T: Stream + Unpin,
 {
     fn from_iter<I: IntoIterator<Item = (K, T)>>(iter: I) -> Self {
         let mut maps = Self::new();
@@ -183,8 +183,8 @@ where
 
 impl<K, T> Stream for StreamMap<K, T>
 where
-    K: Clone + PartialEq + Send + Unpin + 'static,
-    T: Stream + Unpin + Send + 'static,
+    K: Clone + PartialEq + Unpin,
+    T: Stream + Unpin,
 {
     type Item = (K, T::Item);
 
@@ -232,8 +232,8 @@ where
 
 impl<K, T> FusedStream for StreamMap<K, T>
 where
-    K: Clone + PartialEq + Send + Unpin + 'static,
-    T: Stream + Unpin + Send + 'static,
+    K: Clone + PartialEq + Unpin,
+    T: Stream + Unpin,
 {
     fn is_terminated(&self) -> bool {
         self.list.is_terminated()
@@ -289,7 +289,7 @@ mod test {
         map.insert(1, futures::stream::once(async { 10 }).boxed());
         map.insert(2, futures::stream::once(async { 20 }).boxed());
 
-        map.insert(3, futures::stream::iter(vec![30, 40, 50]).boxed());
+        map.insert(3, futures::stream::iter(alloc::vec![30, 40, 50]).boxed());
 
         futures::executor::block_on(async move {
             assert_eq!(map.next().await, Some((1, 10)));

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -4,10 +4,10 @@ pub mod timeout_map;
 pub mod timeout_set;
 
 use crate::common::InnerMap;
+use core::pin::Pin;
+use core::task::{Context, Poll, Waker};
 use futures::stream::{FusedStream, SelectAll};
 use futures::{Stream, StreamExt};
-use std::pin::Pin;
-use std::task::{Context, Poll, Waker};
 
 /// Combining multiple streams into one, with each stream having a unique key.
 pub struct StreamMap<K, S> {

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1,6 +1,8 @@
 pub mod optional;
 pub mod set;
+#[cfg(feature = "std")]
 pub mod timeout_map;
+#[cfg(feature = "std")]
 pub mod timeout_set;
 
 use crate::common::InnerMap;

--- a/src/stream/optional.rs
+++ b/src/stream/optional.rs
@@ -2,9 +2,9 @@ use crate::optional::Optional;
 
 /// A reusable stream that is the equivalent to an `Option`.
 ///
-/// By default, this future will be empty, which would return  [`Poll::Pending`] when polled,
+/// By default, this future will be empty, which would return [`Poll::Pending`] when polled,
 /// but if a [`Stream`] is supplied either upon construction via [`OptionalStream::new`] or
-/// is set via [`OptionalStream::replace`], the stream could later polled once [`OptionalStream`]
+/// is set via [`OptionalStream::replace`], the stream could later poll once [`OptionalStream`]
 /// is polled. Once the stream is polled to completion, [`OptionalStream`] will be empty.
 #[deprecated(note = "Use Optional instead")]
 pub type OptionalStream<S> = Optional<S>;

--- a/src/stream/set.rs
+++ b/src/stream/set.rs
@@ -12,7 +12,7 @@ pub struct StreamSet<S> {
 
 impl<S> Default for StreamSet<S>
 where
-    S: Stream + Send + Unpin + 'static,
+    S: Stream + Unpin,
 {
     fn default() -> Self {
         Self::new()
@@ -21,7 +21,7 @@ where
 
 impl<S> StreamSet<S>
 where
-    S: Stream + Send + Unpin + 'static,
+    S: Stream + Unpin,
 {
     /// Creates an empty ['StreamSet`]
     pub fn new() -> Self {
@@ -70,7 +70,7 @@ where
 
 impl<S> FromIterator<S> for StreamSet<S>
 where
-    S: Stream + Send + Unpin + 'static,
+    S: Stream + Unpin,
 {
     fn from_iter<I: IntoIterator<Item = S>>(iter: I) -> Self {
         let mut maps = Self::new();
@@ -83,7 +83,7 @@ where
 
 impl<S> Stream for StreamSet<S>
 where
-    S: Stream + Send + Unpin + 'static,
+    S: Stream + Unpin,
 {
     type Item = S::Item;
 
@@ -100,7 +100,7 @@ where
 
 impl<S> FusedStream for StreamSet<S>
 where
-    S: Stream + Send + Unpin + 'static,
+    S: Stream + Unpin,
 {
     fn is_terminated(&self) -> bool {
         self.map.is_terminated()

--- a/src/stream/set.rs
+++ b/src/stream/set.rs
@@ -2,8 +2,8 @@ use futures::{Stream, StreamExt};
 use std::pin::Pin;
 
 use super::StreamMap;
+use core::task::{Context, Poll};
 use futures::stream::FusedStream;
-use std::task::{Context, Poll};
 
 pub struct StreamSet<S> {
     id: i64,

--- a/src/stream/set.rs
+++ b/src/stream/set.rs
@@ -1,5 +1,5 @@
+use core::pin::Pin;
 use futures::{Stream, StreamExt};
-use std::pin::Pin;
 
 use super::StreamMap;
 use core::task::{Context, Poll};

--- a/src/stream/timeout_map.rs
+++ b/src/stream/timeout_map.rs
@@ -1,11 +1,11 @@
 use crate::common::Timed;
 use crate::stream::StreamMap;
+use core::ops::{Deref, DerefMut};
+use core::pin::Pin;
+use core::task::{Context, Poll};
+use core::time::Duration;
 use futures::stream::FusedStream;
 use futures::{Stream, StreamExt};
-use std::ops::{Deref, DerefMut};
-use std::pin::Pin;
-use std::task::{Context, Poll};
-use std::time::Duration;
 
 pub struct TimeoutStreamMap<K, S> {
     duration: Duration,

--- a/src/stream/timeout_map.rs
+++ b/src/stream/timeout_map.rs
@@ -27,8 +27,8 @@ impl<K, S> DerefMut for TimeoutStreamMap<K, S> {
 
 impl<K, S> TimeoutStreamMap<K, S>
 where
-    K: Clone + PartialEq + Send + Unpin + 'static,
-    S: Stream + Send + Unpin + 'static,
+    K: Clone + PartialEq + Unpin,
+    S: Stream + Unpin,
 {
     /// Create an empty [`TimeoutStreamMap`]
     pub fn new(duration: Duration) -> Self {
@@ -48,8 +48,8 @@ where
 
 impl<K, S> Stream for TimeoutStreamMap<K, S>
 where
-    K: Clone + PartialEq + Send + Unpin + 'static,
-    S: Stream + Send + Unpin + 'static,
+    K: Clone + PartialEq + Unpin,
+    S: Stream + Unpin,
 {
     type Item = (K, std::io::Result<S::Item>);
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
@@ -63,8 +63,8 @@ where
 
 impl<K, S> FusedStream for TimeoutStreamMap<K, S>
 where
-    K: Clone + PartialEq + Send + Unpin + 'static,
-    S: Stream + Send + Unpin + 'static,
+    K: Clone + PartialEq + Unpin,
+    S: Stream + Unpin,
 {
     fn is_terminated(&self) -> bool {
         self.map.is_terminated()

--- a/src/stream/timeout_set.rs
+++ b/src/stream/timeout_set.rs
@@ -27,7 +27,7 @@ impl<S> DerefMut for TimeoutStreamSet<S> {
 
 impl<S> TimeoutStreamSet<S>
 where
-    S: Stream + Send + Unpin + 'static,
+    S: Stream + Unpin,
 {
     /// Create an empty ['TimeoutStreamSet']
     pub fn new(duration: Duration) -> Self {
@@ -45,7 +45,7 @@ where
 
 impl<S> Stream for TimeoutStreamSet<S>
 where
-    S: Stream + Send + Unpin + 'static,
+    S: Stream + Unpin,
 {
     type Item = std::io::Result<S::Item>;
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
@@ -59,7 +59,7 @@ where
 
 impl<S> FusedStream for TimeoutStreamSet<S>
 where
-    S: Stream + Send + Unpin + 'static,
+    S: Stream + Unpin,
 {
     fn is_terminated(&self) -> bool {
         self.set.is_terminated()

--- a/src/stream/timeout_set.rs
+++ b/src/stream/timeout_set.rs
@@ -1,11 +1,11 @@
 use crate::common::Timed;
 use crate::stream::set::StreamSet;
+use core::ops::{Deref, DerefMut};
+use core::pin::Pin;
+use core::task::{Context, Poll};
+use core::time::Duration;
 use futures::stream::FusedStream;
 use futures::{Stream, StreamExt};
-use std::ops::{Deref, DerefMut};
-use std::pin::Pin;
-use std::task::{Context, Poll};
-use std::time::Duration;
 
 pub struct TimeoutStreamSet<S> {
     duration: Duration,


### PR DESCRIPTION

Additionally, this PR relaxes `Send + 'static` 

Note:
- This is a start but still utilizes `std` for timeout varisnts and `alloc` for some features to work.
- Right now, `Unpin` is still used due to the underlining requirements from `FuturesUnordered`. This might change in the future so that no-std will use some variant of it that doesnt require `Unpin`, allowing support for `!Unpin` but for now `Unpin` is still required.